### PR TITLE
bugfix/pr#14

### DIFF
--- a/examples/restaurant_app/main.go
+++ b/examples/restaurant_app/main.go
@@ -52,6 +52,11 @@ func main() {
 		}
 
 	})
+	app.Post("/", puff.Field{}, func(c *puff.Context) {
+		c.SendResponse(puff.GenericResponse{
+			Content: "This route as well as the get route should pop up in swagger.",
+		})
+	})
 	f := puff.Field{
 		PathParams: map[string]reflect.Kind{"name": reflect.String},
 	}

--- a/openapi.go
+++ b/openapi.go
@@ -242,11 +242,7 @@ func addRoute(router Router, route Route, tags *[]Tag, tagNames *[]string, paths
 		Responses:   map[string]Response{},
 		Description: description, // TODO: needs to be dynamic on route
 	}
-	pathItem := PathItem{}
-	storedPathItem, ok := (*paths)[route.fullPath]
-	if ok {
-		pathItem = storedPathItem
-	}
+	pathItem := (*paths)[route.fullPath]
 	switch route.Protocol {
 	// TODO: handle other protocols
 	case http.MethodGet:

--- a/openapi.go
+++ b/openapi.go
@@ -243,6 +243,10 @@ func addRoute(router Router, route Route, tags *[]Tag, tagNames *[]string, paths
 		Description: description, // TODO: needs to be dynamic on route
 	}
 	pathItem := PathItem{}
+	storedPathItem, ok := (*paths)[route.fullPath]
+	if ok {
+		pathItem = storedPathItem
+	}
 	switch route.Protocol {
 	// TODO: handle other protocols
 	case http.MethodGet:
@@ -255,7 +259,6 @@ func addRoute(router Router, route Route, tags *[]Tag, tagNames *[]string, paths
 		pathItem.Post = pathMethod
 	case http.MethodDelete:
 		pathItem.Delete = pathMethod
-
 	}
 	(*paths)[route.fullPath] = pathItem
 


### PR DESCRIPTION
# PR #14 Bugfix
Bug: Only the last defined route would appear for the route if multiple different methods are defined on the same route.

Code Explanation:
```golang

pasta_router.Get("/cheese", pasta_cheese_input, func(c *puff.Context) {
	// ...
})

pasta_router.Post("/cheese", pasta_newcheese_input, func(c *puff.Context) {
	// ...
})

```

In this example, when opening the swagger page, only [POST] /cheese would be defined. [GET] /cheese would not be shown on the swagger page.

Cause: Every time a route would go through `addOpenAPIDocs` in `openapi.go`, a new empty `PathItem{}` would be created for it, whether or not it already had one.

Code with bugs ([openapi.go:245](https://github.com/nikumar1206/puff/blob/365a8f52460d1dc0fe43f64f0031637fee273160/openapi.go#L245C2-L260C37l)):
```golang
pathItem := PathItem{}
switch route.Protocol {
// TODO: handle other protocols
case http.MethodGet:
	pathItem.Get = pathMethod
case http.MethodPut:
	pathItem.Put = pathMethod
case http.MethodPatch:
	pathItem.Patch = pathMethod
case http.MethodPost:
	pathItem.Post = pathMethod
case http.MethodDelete:
	pathItem.Delete = pathMethod
}
(*paths)[route.fullPath] = pathItem
```

Code without bugs:
```golang
pathItem := (*paths)[route.fullPath]
switch route.Protocol {
	// ...
}
(*paths)[route.fullPath] = pathItem
```

The code without the bug will first check if an empty path item already exists.