### PR TITLE
🚨 bugfix pr#21 🚨

### DIFF
--- a/examples/restaurant_app/routes/pizza.go
+++ b/examples/restaurant_app/routes/pizza.go
@@ -30,7 +30,7 @@ func getPizza(c *puff.Context) {
 }
 
 type Pizza struct {
-	Name        string   `json:"name"`
+	Name        string   `json:"name,omitempty"`
 	Ingredients []string `json:"ingredients"`
 }
 

--- a/field.go
+++ b/field.go
@@ -48,7 +48,7 @@ func validate(input map[string]any, schemaType reflect.Type) (bool, error) {
 		s := strings.Split(jsonTag, ",")
 		jsonTagName := s[0]
 		if jsonTagName != "" {
-			name = jsonTag
+			name = jsonTagName
 		}
 		if nameTag != "" { // name takes priority over json
 			name = nameTag


### PR DESCRIPTION
the bug (field.go/validate), introduced in pr #21: adding omitempty to the json struct field tag in a definition would have the validator not expect the fields even though they were expected.

reproduce error: have the json struct field tag include ,omitempty (a normal parameter to the tag).
 
context: the validate function checks for unexpected and expected but not found json keys in the input. puff includes support for alternative names other than name in the struct with the `json` struct field tag and the `name` struct field tag.

what happened: there was a discrepancy between the input schema and the name we were checking for in the input. the validator split the struct field's tag to get only the name but instead used the whole tag (including the omitempty) when checking the input and schema.